### PR TITLE
MeshUVSpaceRenderer Decal Map PR Feedback

### DIFF
--- a/packages/dev/core/src/Meshes/meshUVSpaceRenderer.ts
+++ b/packages/dev/core/src/Meshes/meshUVSpaceRenderer.ts
@@ -198,10 +198,11 @@ export class MeshUVSpaceRenderer {
         // Create the diffuse render target texture if it doesn't exist
         if (!this.texture && !this._options.uvEdgeBlending && !this._decalTexture) {
             this._updateRTT();
-        }
-        else if(this.texture && !this._userCreatedTextureSetup && !this._options.uvEdgeBlending && !this._decalTexture) { 
+        } else if(this.texture && !this._userCreatedTextureSetup && !this._options.uvEdgeBlending && !this._decalTexture) { 
             this._updateRTT();
-        } else if(!this._decalTexture) {
+        } else if(this.texture && !this._userCreatedTextureSetup && this._options.uvEdgeBlending && !this._decalTexture) {
+            this._createDecalDiffuseRTT();
+        } else if(!this.texture && this._options.uvEdgeBlending && !this._decalTexture) {
             this._createDecalDiffuseRTT();
         }
 


### PR DESCRIPTION
> don't use "any" as types
use the public/private access modifier as appropriate (some properties don't have any)
don't make renderTexture async, it is not needed
don't create a new mask material per meshUVSpaceRenderer instance. You should do much like _GetShader (something like _GetMaskShader)
remove the finalMaterial, which is not needed
remove the try/catch constructs, as it's not expected there could be any error in this code (and if there are, we prefer they are issued directly from the faulty code)
make sure that there's no breaking change with the texture property. Currently, the user can set it to use his own texture instead of letting the class creates one. In the current PR, it is not possible.